### PR TITLE
Fixed crash on rendering. 

### DIFF
--- a/MatrixEngine/main.cpp
+++ b/MatrixEngine/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "matrix\MatrixEngine.h"
+#include "matrix/MatrixEngine.h"
 
 using namespace std;
 
@@ -18,19 +18,19 @@ int main(int arcg, char **argv){
 
 	GLXSDLDevice device;
 	device.Construct(SDL_INIT_EVERYTHING, glm::vec3(800, 600, 32), false);
-	device.SetCaption("Matrix Engine"); 
+	device.SetCaption("Matrix Engine");
 
 
 	GLXSDLSceneGraph *sceneGraph = new GLXSDLSceneGraph();
-	 
+
 	GLXSDLSceneInstance *instance = new GLXSDLSceneInstance();
 	GLXSDLSceneEntity *node = new GLXSDLSceneEntity(instance);
 	sceneGraph->AddEntityNode(node);
-	
+
 	node->AddChild(new GLXSDLSceneEntity(new GLXSDLSceneInstance(),"a"));
 	node->GetChild(0)->AddChild(new GLXSDLSceneEntity(new GLXSDLSceneInstance(), "subchild"));
 	node->GetChild(0)->GetChild(0)->AddChild(new GLXSDLSceneEntity(new GLXSDLSceneInstance(), "sub-sub-child"));
-	 
+
 	node->AddChild(new GLXSDLSceneEntity(new GLXSDLSceneInstance(),"b"));
 	node->AddChild(new GLXSDLSceneEntity(new GLXSDLSceneInstance(),"c"));
 	node->AddChild(new GLXSDLSceneEntity(new GLXSDLSceneInstance(),"d"));
@@ -49,7 +49,7 @@ int main(int arcg, char **argv){
 	renderer->LoadShader("data/shader/default_model.vs", "data/shader/default_model.fs");
 
 	GLXSDLSceneEntity *node2 = new GLXSDLSceneEntity(renderer,"MeshRenderer1");
-	node2->translate(vec3(0.0, 0.0, -1.0));
+	node2->translate(vec3(0.0, 0.0, -10.0));
 	node2->rotate(0.0, 1.0, 1.0, 1.0);
 	node2->scale(vec3(1.0, 1.0, 1.0));
 
@@ -61,10 +61,13 @@ int main(int arcg, char **argv){
 		cout << "Node " << i << ": " << sceneGraph->GetNode(i)->getNodeName() << endl;
 		PrintChildren(sceneGraph->GetNode(i));
 	}
-	
+
 	cout << endl << endl << endl;
 
 	cout << "Now rendering" << endl;
+
+    GLXSDLCamera *camera = new GLXSDLCamera();
+    camera->SetPosition(vec3(0.0,0.0,0.0));
 
 	while (running)
 	{
@@ -73,13 +76,17 @@ int main(int arcg, char **argv){
 		GLXSDLRenderPipeline::PrepareForRendering();
 		GLXSDLRenderPipeline::ClearScreen(vec4(0.0, 0.0, 1.0, 1.0));
 
+        camera->ApplyTransform();
+
 		sceneGraph->RenderScene();
 
 		GLXSDLRenderPipeline::SwapBuffer();
 	}
 
-	delete sceneGraph;
+    delete camera;
 	delete mesh;
+	delete sceneGraph;
+
 
 	MatrixEngine::MatrixEngine_Quit();
 	return 0;

--- a/MatrixEngine/matrix/Mesh.cpp
+++ b/MatrixEngine/matrix/Mesh.cpp
@@ -42,6 +42,10 @@ Mesh::Mesh(){
 
 }
 
+Mesh::~Mesh() {
+    cout << "Deleting mesh " << endl;
+}
+
 void Mesh::LoadFromFile(string file) {
 	cout << "Loading " << file << ".." << endl;
 
@@ -54,7 +58,7 @@ void Mesh::LoadFromFile(string file) {
 	}
 
 
-	
+
 	processNode(scene->mRootNode, scene);
 
 	cout << "Mesh " << file << " loaded. " << endl;
@@ -74,7 +78,7 @@ void Mesh::processNode(aiNode *node, const aiScene *scene) {
 
 void Mesh::processMesh(aiMesh *mesh, const aiScene *scene) {
 	MeshSection section;
-	
+
 	for (int i = 0; i < mesh->mNumVertices; i++) {
 		vec3 vert(mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z);
 		vec3 norm(mesh->mNormals[i].x,  mesh->mNormals[i].y,  mesh->mNormals[i].z);
@@ -116,7 +120,7 @@ void Mesh::processMesh(aiMesh *mesh, const aiScene *scene) {
 	section.material = material;
 
 	for (int i = 0; i < mat->GetTextureCount(aiTextureType_DIFFUSE); i++) {
-		aiString name; 
+		aiString name;
 		mat->GetTexture(aiTextureType_DIFFUSE, i, &name);
 
 		section.material.texture_diffuse.load_from_file(name.C_Str());

--- a/MatrixEngine/matrix/Mesh.h
+++ b/MatrixEngine/matrix/Mesh.h
@@ -5,11 +5,19 @@
 #include "Material.h"
 #include "VAO.h"
 
+#ifdef WIN32
 
 #include <assimp\Importer.hpp>
 #include <assimp\scene.h>
 #include <assimp\postprocess.h>
 
+#else
+
+#include <assimp/Importer.hpp>
+#include <assimp/scene.h>
+#include <assimp/postprocess.h>
+
+#endif // WIN32
 
 using namespace Assimp;
 
@@ -38,13 +46,14 @@ class MeshSection {
 class Components::Mesh {
 	public :
 		Mesh();
+        ~Mesh();
 
 		void LoadFromFile(string file);
 
-		
+
 	protected :
 		std::vector<MeshSection> sections;
-		
+
 		friend class MatrixEngine::Graphics::Render::MeshRenderer;
 
 	private :

--- a/MatrixEngine/matrix/MeshRenderer.cpp
+++ b/MatrixEngine/matrix/MeshRenderer.cpp
@@ -13,7 +13,6 @@ MeshRenderer::MeshRenderer(Components::Mesh *mesh) : GLXSDLSceneInstance() {
 
 MeshRenderer::~MeshRenderer()
 {
-
 	if (shader)
 	{
 		shader->detach_shader(shader_vert);
@@ -47,7 +46,7 @@ void MeshRenderer::LoadShader(string vs, string fs, string gs)
 }
 
 void MeshRenderer::Render() {
-	
+
 	entity->buildTransformMatrix();
 	mat4 transformMatrix = entity->getTransofrmMatrix();
 
@@ -60,7 +59,6 @@ void MeshRenderer::Render() {
 		shader->sendUniform1i(shader->getUniformLocation("texture_bump"), 2);
 
 		vec3 camera_pos = -MatrixEngine::_pCurrentCamera->GetPosition();
-
 		shader->sendUniform3f(shader->getUniformLocation("camera_position"), camera_pos);
 
 		/*if (Graphics::_pCurrentTextureCube)

--- a/MatrixEngine/matrix/matrix_engine_internal.h
+++ b/MatrixEngine/matrix/matrix_engine_internal.h
@@ -11,6 +11,8 @@
 #include <string>
 
 #define GLM_FORCE_INLINE
+#ifdef WIN32
+
 #include <glm\glm.hpp>
 
 #include <glm\vec2.hpp>
@@ -34,6 +36,34 @@
 #include <assimp\scene.h>
 #include <assimp\postprocess.h>
 
+
+#else //UNIX
+
+#include <glm/glm.hpp>
+
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
+
+#include <glm/mat4x4.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/constants.hpp>
+
+#include <GL/glew.h>
+
+#include <SDL/SDL.h>
+#include <SDL/SDL_image.h>
+
+#define NO_SDL_GLEXT
+#include <SDL/SDL_opengl.h>
+
+#include <assimp/Importer.hpp>
+#include <assimp/scene.h>
+#include <assimp/postprocess.h>
+
+#endif // WIN32
+
 #define PI 3.141592653589793
 
 using namespace std;
@@ -55,14 +85,14 @@ namespace MatrixEngine {
 	class GLXSDLDevice;
 	class GLXSDLRenderPipeline;
 	class GLXSDLCamera;
-	
+
 	namespace Scene {
 		class GLXSDLSceneGraph;
 		class GLXSDLSceneEntity;
 		class GLXSDLSceneInstance;
 
 		extern GLXSDLSceneGraph *_pCurrentSceneGraph;
-		
+
 
 		namespace Components {
 			class Mesh;


### PR DESCRIPTION
MeshRenderer.cpp line 61: trying to access MatrixEngine::_pCurrentCamera but it wasn't initialized. Fixed headers inclusion to work both on Linux and Windows
